### PR TITLE
add basic infra definition for a static serving bucket

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,20 +26,21 @@ jobs:
           node-version-file: .nvmrc
           cache: 'npm'
 
-      - uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: eu-west-1
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-
       - run: npm ci
       - run: npm run lint
       - run: npm test
       - run: npm run build
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: eu-west-1
+          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
 
       - uses: guardian/actions-riff-raff@v2
         with:
           projectName: Content Platforms::recipes-backend
           configPath: "cdk/cdk.out/riff-raff.yaml"
           contentDirectories: |
-            cfn-eu-west-1-content-api-recipes-backend:
-              - cdk/cdk.out
+            cdk.out:
+              - cdk/cdk.out/RecipesBackend-euwest-1-CODE.template.json
+              - cdk/cdk.out/RecipesBackend-euwest-1-PROD.template.json

--- a/README.md
+++ b/README.md
@@ -5,6 +5,30 @@
 This is a backend service that translates data from the Content API into a format that apps like 
 https://github.com/guardian/ios-feast can use.
 
+## Running CDK
+
+The CDK stack is integrated with `nx`, so the regular "npm run synth" in the cdk directory won't work.
+
+Instead, you can do:
+
+```bash
+npm run build
+```
+
+To build _everything_, including the CDK.
+
+```bash
+npm test
+```
+
+Will run the tests on everyhing, including CDK (therefore it will fail if the CDK snapshot is out of sync)
+
+```bash
+npm run update-cdk
+```
+
+Will update the CDK snapshot and allow the tests to pass again
+
 ## How does it work?
 
 TBD

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -6,120 +6,70 @@ exports[`The RecipesBackend stack matches the snapshot 1`] = `
     "gu:cdk:constructs": [],
     "gu:cdk:version": "TEST",
   },
-  "Parameters": {
-    "AssetParametersb7f33614a69548d6bafe224d751a7ef238cde19097415e553fe8b63a4c8fd8a6ArtifactHash7E7F1011": {
-      "Description": "Artifact hash for asset "b7f33614a69548d6bafe224d751a7ef238cde19097415e553fe8b63a4c8fd8a6"",
-      "Type": "String",
-    },
-    "AssetParametersb7f33614a69548d6bafe224d751a7ef238cde19097415e553fe8b63a4c8fd8a6S3Bucket003C01C0": {
-      "Description": "S3 bucket for asset "b7f33614a69548d6bafe224d751a7ef238cde19097415e553fe8b63a4c8fd8a6"",
-      "Type": "String",
-    },
-    "AssetParametersb7f33614a69548d6bafe224d751a7ef238cde19097415e553fe8b63a4c8fd8a6S3VersionKey63B90A34": {
-      "Description": "S3 key for asset version "b7f33614a69548d6bafe224d751a7ef238cde19097415e553fe8b63a4c8fd8a6"",
-      "Type": "String",
-    },
-  },
   "Resources": {
-    "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F": {
-      "DependsOn": [
-        "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
-      ],
+    "staticcdnRead42C381A5": {
       "Properties": {
-        "Code": {
-          "S3Bucket": {
-            "Ref": "AssetParametersb7f33614a69548d6bafe224d751a7ef238cde19097415e553fe8b63a4c8fd8a6S3Bucket003C01C0",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
           },
-          "S3Key": {
-            "Fn::Join": [
-              "",
-              [
-                {
-                  "Fn::Select": [
-                    0,
-                    {
-                      "Fn::Split": [
-                        "||",
-                        {
-                          "Ref": "AssetParametersb7f33614a69548d6bafe224d751a7ef238cde19097415e553fe8b63a4c8fd8a6S3VersionKey63B90A34",
-                        },
-                      ],
-                    },
-                  ],
-                },
-                {
-                  "Fn::Select": [
-                    1,
-                    {
-                      "Fn::Split": [
-                        "||",
-                        {
-                          "Ref": "AssetParametersb7f33614a69548d6bafe224d751a7ef238cde19097415e553fe8b63a4c8fd8a6S3VersionKey63B90A34",
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            ],
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/recipes-api",
           },
-        },
-        "Description": {
-          "Fn::Join": [
-            "",
-            [
-              "Lambda function for auto-deleting objects in ",
-              {
-                "Ref": "staticstaticServing53194089",
-              },
-              " S3 bucket.",
-            ],
-          ],
-        },
-        "Handler": "index.handler",
-        "MemorySize": 128,
-        "Role": {
-          "Fn::GetAtt": [
-            "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs18.x",
-        "Timeout": 900,
+          {
+            "Key": "Stack",
+            "Value": "content-api",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "UserName": "recipes-api-cdn-TEST",
       },
-      "Type": "AWS::Lambda::Function",
+      "Type": "AWS::IAM::User",
     },
-    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092": {
+    "staticcdnReadDefaultPolicy5DF868F9": {
       "Properties": {
-        "AssumeRolePolicyDocument": {
+        "PolicyDocument": {
           "Statement": [
             {
-              "Action": "sts:AssumeRole",
+              "Action": "s3:GetObject",
               "Effect": "Allow",
-              "Principal": {
-                "Service": "lambda.amazonaws.com",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "staticstaticServing53194089",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
               },
             },
           ],
           "Version": "2012-10-17",
         },
-        "ManagedPolicyArns": [
+        "PolicyName": "staticcdnReadDefaultPolicy5DF868F9",
+        "Users": [
           {
-            "Fn::Sub": "arn:\${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+            "Ref": "staticcdnRead42C381A5",
           },
         ],
       },
-      "Type": "AWS::IAM::Role",
+      "Type": "AWS::IAM::Policy",
     },
     "staticstaticServing53194089": {
       "DeletionPolicy": "Delete",
       "Properties": {
         "BucketName": "recipes-backend-static-test",
         "Tags": [
-          {
-            "Key": "aws-cdk:auto-delete-objects",
-            "Value": "true",
-          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -141,25 +91,6 @@ exports[`The RecipesBackend stack matches the snapshot 1`] = `
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Delete",
     },
-    "staticstaticServingAutoDeleteObjectsCustomResource901DD148": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "staticstaticServingPolicyC6F5921B",
-      ],
-      "Properties": {
-        "BucketName": {
-          "Ref": "staticstaticServing53194089",
-        },
-        "ServiceToken": {
-          "Fn::GetAtt": [
-            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "Custom::S3AutoDeleteObjects",
-      "UpdateReplacePolicy": "Delete",
-    },
     "staticstaticServingPolicyC6F5921B": {
       "Properties": {
         "Bucket": {
@@ -177,66 +108,6 @@ exports[`The RecipesBackend stack matches the snapshot 1`] = `
               "Effect": "Deny",
               "Principal": {
                 "AWS": "*",
-              },
-              "Resource": [
-                {
-                  "Fn::GetAtt": [
-                    "staticstaticServing53194089",
-                    "Arn",
-                  ],
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      {
-                        "Fn::GetAtt": [
-                          "staticstaticServing53194089",
-                          "Arn",
-                        ],
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            {
-              "Action": "s3:GetObject",
-              "Effect": "Allow",
-              "Principal": {
-                "AWS": "*",
-              },
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    {
-                      "Fn::GetAtt": [
-                        "staticstaticServing53194089",
-                        "Arn",
-                      ],
-                    },
-                    "/*",
-                  ],
-                ],
-              },
-            },
-            {
-              "Action": [
-                "s3:PutBucketPolicy",
-                "s3:GetBucket*",
-                "s3:List*",
-                "s3:DeleteObject*",
-              ],
-              "Effect": "Allow",
-              "Principal": {
-                "AWS": {
-                  "Fn::GetAtt": [
-                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
-                    "Arn",
-                  ],
-                },
               },
               "Resource": [
                 {

--- a/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
+++ b/cdk/lib/__snapshots__/recipes-backend.test.ts.snap
@@ -6,5 +6,267 @@ exports[`The RecipesBackend stack matches the snapshot 1`] = `
     "gu:cdk:constructs": [],
     "gu:cdk:version": "TEST",
   },
+  "Parameters": {
+    "AssetParametersb7f33614a69548d6bafe224d751a7ef238cde19097415e553fe8b63a4c8fd8a6ArtifactHash7E7F1011": {
+      "Description": "Artifact hash for asset "b7f33614a69548d6bafe224d751a7ef238cde19097415e553fe8b63a4c8fd8a6"",
+      "Type": "String",
+    },
+    "AssetParametersb7f33614a69548d6bafe224d751a7ef238cde19097415e553fe8b63a4c8fd8a6S3Bucket003C01C0": {
+      "Description": "S3 bucket for asset "b7f33614a69548d6bafe224d751a7ef238cde19097415e553fe8b63a4c8fd8a6"",
+      "Type": "String",
+    },
+    "AssetParametersb7f33614a69548d6bafe224d751a7ef238cde19097415e553fe8b63a4c8fd8a6S3VersionKey63B90A34": {
+      "Description": "S3 key for asset version "b7f33614a69548d6bafe224d751a7ef238cde19097415e553fe8b63a4c8fd8a6"",
+      "Type": "String",
+    },
+  },
+  "Resources": {
+    "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F": {
+      "DependsOn": [
+        "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "AssetParametersb7f33614a69548d6bafe224d751a7ef238cde19097415e553fe8b63a4c8fd8a6S3Bucket003C01C0",
+          },
+          "S3Key": {
+            "Fn::Join": [
+              "",
+              [
+                {
+                  "Fn::Select": [
+                    0,
+                    {
+                      "Fn::Split": [
+                        "||",
+                        {
+                          "Ref": "AssetParametersb7f33614a69548d6bafe224d751a7ef238cde19097415e553fe8b63a4c8fd8a6S3VersionKey63B90A34",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  "Fn::Select": [
+                    1,
+                    {
+                      "Fn::Split": [
+                        "||",
+                        {
+                          "Ref": "AssetParametersb7f33614a69548d6bafe224d751a7ef238cde19097415e553fe8b63a4c8fd8a6S3VersionKey63B90A34",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+        },
+        "Description": {
+          "Fn::Join": [
+            "",
+            [
+              "Lambda function for auto-deleting objects in ",
+              {
+                "Ref": "staticstaticServing53194089",
+              },
+              " S3 bucket.",
+            ],
+          ],
+        },
+        "Handler": "index.handler",
+        "MemorySize": 128,
+        "Role": {
+          "Fn::GetAtt": [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Timeout": 900,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Sub": "arn:\${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "staticstaticServing53194089": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "BucketName": "recipes-backend-static-test",
+        "Tags": [
+          {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/recipes-api",
+          },
+          {
+            "Key": "Stack",
+            "Value": "content-api",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "staticstaticServingAutoDeleteObjectsCustomResource901DD148": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "staticstaticServingPolicyC6F5921B",
+      ],
+      "Properties": {
+        "BucketName": {
+          "Ref": "staticstaticServing53194089",
+        },
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::S3AutoDeleteObjects",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "staticstaticServingPolicyC6F5921B": {
+      "Properties": {
+        "Bucket": {
+          "Ref": "staticstaticServing53194089",
+        },
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*",
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "staticstaticServing53194089",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "staticstaticServing53194089",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "*",
+              },
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "staticstaticServing53194089",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "s3:PutBucketPolicy",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::GetAtt": [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn",
+                  ],
+                },
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "staticstaticServing53194089",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "staticstaticServing53194089",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
+  },
 }
 `;

--- a/cdk/lib/recipes-backend.ts
+++ b/cdk/lib/recipes-backend.ts
@@ -1,10 +1,37 @@
 import type { GuStackProps } from "@guardian/cdk/lib/constructs/core";
 import { GuStack } from "@guardian/cdk/lib/constructs/core";
+// import {GuKinesisLambdaExperimental} from "@guardian/cdk/lib/experimental/patterns";
+// import { StreamRetry } from "@guardian/cdk/lib/utils/lambda";
+// import { Duration, type App } from "aws-cdk-lib";
+// import { Runtime } from "aws-cdk-lib/aws-lambda";
 import type { App } from "aws-cdk-lib";
+import { StaticServing } from "./static-serving";
 
 export class RecipesBackend extends GuStack {
   constructor(scope: App, id: string, props: GuStackProps) {
     super(scope, id, props);
 
+    //const app = this.app ?? "recipes-backend";
+
+    new StaticServing(this, "static");
+
+    //TODO - this is how we can simply connect to an existing kinesis stream. But we have nothing to
+    //connect to it yet! - this will be uncommented once we do.
+
+    // new GuKinesisLambdaExperimental(this, "updaterLambda", {
+    //   monitoringConfiguration: {noMonitoring: true},
+    //   existingKinesisStream: {
+    //     externalKinesisStreamName: "blah"
+    //   },
+    //   errorHandlingConfiguration: {
+    //     retryBehaviour: StreamRetry.maxAttempts(5),
+    //     bisectBatchOnError: true,
+    //   },
+    //   runtime: Runtime.NODEJS_18_X,
+    //   app,
+    //   handler: "main.handler",
+    //   fileName: "recipe-backend-updater.zip",
+    //   timeout: Duration.seconds(30)
+    // })
   }
 }

--- a/cdk/lib/static-serving.ts
+++ b/cdk/lib/static-serving.ts
@@ -1,0 +1,25 @@
+import type { GuStack } from "@guardian/cdk/lib/constructs/core";
+import { RemovalPolicy } from "aws-cdk-lib";
+import { Bucket, type IBucket } from "aws-cdk-lib/aws-s3";
+import { Construct } from "constructs";
+
+
+
+export class StaticServing extends Construct {
+  staticBucket: IBucket;
+
+  constructor(scope:GuStack, id:string) {
+    super(scope, id);
+
+    const maybePreview = scope.stack.endsWith("-preview") ? "-preview" : "";
+
+    this.staticBucket = new Bucket(this, "staticServing", {
+      bucketName: `recipes-backend${maybePreview}-static-${scope.stage.toLowerCase()}`,
+      enforceSSL: true,
+      removalPolicy: RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
+      publicReadAccess: true,     //TODO: we will set up authenticated CDN access once initial POC is done
+    });
+
+  }
+}

--- a/cdk/lib/static-serving.ts
+++ b/cdk/lib/static-serving.ts
@@ -1,5 +1,6 @@
 import type { GuStack } from "@guardian/cdk/lib/constructs/core";
 import { RemovalPolicy } from "aws-cdk-lib";
+import { Effect, PolicyStatement, User } from "aws-cdk-lib/aws-iam";
 import { Bucket, type IBucket } from "aws-cdk-lib/aws-s3";
 import { Construct } from "constructs";
 
@@ -17,9 +18,16 @@ export class StaticServing extends Construct {
       bucketName: `recipes-backend${maybePreview}-static-${scope.stage.toLowerCase()}`,
       enforceSSL: true,
       removalPolicy: RemovalPolicy.DESTROY,
-      autoDeleteObjects: true,
-      publicReadAccess: true,     //TODO: we will set up authenticated CDN access once initial POC is done
     });
 
+    const cdnReadUser = new User(this, "cdnRead", {
+      userName: `recipes-api-cdn${maybePreview}-${scope.stage}`,
+    });
+
+    cdnReadUser.addToPolicy(new PolicyStatement({
+      effect: Effect.ALLOW,
+      actions: ["s3:GetObject"],
+      resources: [this.staticBucket.bucketArn + '/*'],
+    }));
   }
 }

--- a/cdk/project.json
+++ b/cdk/project.json
@@ -45,6 +45,21 @@
 					"codeCoverage": true
 				}
 			}
+		},
+    "update": {
+			"executor": "@nx/jest:jest",
+			"outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+			"options": {
+				"jestConfig": "cdk/jest.config.ts",
+        "updateSnapshot": true,
+				"passWithNoTests": true
+			},
+			"configurations": {
+				"ci": {
+					"ci": true,
+					"codeCoverage": true
+				}
+			}
 		}
 	},
 	"tags": []

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "update-cdk": "nx run cdk:update",
-    "build": "nx run-many --target=build",
+    "build": "nx run-many --target=build --skip-nx-cache",
     "test": "nx run-many --target=test",
     "lint": "nx run-many --target=lint"
   },

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {
+    "update-cdk": "nx run cdk:update",
     "build": "nx run-many --target=build",
     "test": "nx run-many --target=test",
     "lint": "nx run-many --target=lint"


### PR DESCRIPTION
## What does this change?

Adds basic static serving infrastructure so we can road-test CDN behaviour

## How to test

This has been deployed and hooked fastly onto the bucket as per https://docs.fastly.com/en/guides/amazon-s3
